### PR TITLE
Fixed indent_size issue when using tabs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,17 @@ function init(editor) {
 	}
 
 	if (config.indent_style === 'space') {
-		editor.setTabLength(config.indent_size);
-	}
+		editor.setSoftTabs(true);
 
-	if (config.indent_style) {
-		editor.setSoftTabs(config.indent_style === 'space');
+		if (config.indent_size) {
+			editor.setTabLength(config.indent_size);
+		}
+	} else if (config.indent_style === 'tab') {
+		editor.setSoftTabs(false);
+
+		if (config.tab_width) {
+			editor.setTabLength(config.tab_width);
+		}
 	}
 }
 


### PR DESCRIPTION
I was having the issue that I couldn't get it to work with `indent_style = tab`. My Atom is default to soft tabs 2 and was trying to do hard tabs 4 in editorconfig by setting `indent_style = tab` and `indent_size = 4` with no luck as my Atom default was two and the package is only setting indent_size for spaces. This change is what is working for me but not sure if there is a better or more preferred way.
