### PR TITLE
Work properly when no indent_style is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,23 +17,15 @@ function init(editor) {
 			return;
 		}
 
-		let indent_style = null;
+		const indentStyle = config.indent_style || editor.getSoftTabs() ? 'space' : 'tab';
 
-		if (config.indent_style) {
-			// Use the editorconfig indent style
-			indent_style = config.indent_style;
-		} else {
-			// Use the user's default indent style
-			indent_style = editor.getSoftTabs() ? 'space' : 'tab';
-		}
-
-		if (indent_style === 'tab') {
+		if (indentStyle === 'tab') {
 			editor.setSoftTabs(false);
 
 			if (config.tab_width) {
 				editor.setTabLength(config.tab_width);
 			}
-		} else if (indent_style === 'space') {
+		} else if (indentStyle === 'space') {
 			editor.setSoftTabs(true);
 
 			if (config.indent_size) {

--- a/index.js
+++ b/index.js
@@ -17,13 +17,23 @@ function init(editor) {
 			return;
 		}
 
-		if (config.indent_style === 'tab') {
+		let indent_style = null;
+
+		if (config.indent_style) {
+			// Use the editorconfig indent style
+			indent_style = config.indent_style;
+		} else {
+			// Use the user's default indent style
+			indent_style = editor.getSoftTabs() ? 'space' : 'tab';
+		}
+
+		if (indent_style === 'tab') {
 			editor.setSoftTabs(false);
 
 			if (config.tab_width) {
 				editor.setTabLength(config.tab_width);
 			}
-		} else if (config.indent_style === 'space') {
+		} else if (indent_style === 'space') {
 			editor.setSoftTabs(true);
 
 			if (config.indent_size) {


### PR DESCRIPTION
I spent a bit of time trying to figure out why my editorconfig settings weren't working (for indentation), and it turns out I didn't specify an `indent_style`, so the plugin wasn't setting my tab width.

This little patch just infers the `indent_style` from the editor's settings if it isn't set in the user's `editorconfig`.

