### PR TITLE
Fix error with operator precedence

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function init(editor) {
 			return;
 		}
 
-		const indentStyle = config.indent_style || editor.getSoftTabs() ? 'space' : 'tab';
+		const indentStyle = config.indent_style || (editor.getSoftTabs() ? 'space' : 'tab');
 
 		if (indentStyle === 'tab') {
 			editor.setSoftTabs(false);


### PR DESCRIPTION
My editor settings of soft tabs took over even with `indent_style` set to `tab`. This fixes it.