### PR TITLE
Prevent editor from losing selection due to unnecessary encoding changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,9 +51,11 @@ function init(editor) {
 		}
 
 		if (config.charset) {
-			// EditorConfig charset names matches iconv charset names.
-			// Which is used by Atom. So no charset name convertion is needed.
-			editor.setEncoding(config.charset);
+			// By default Atom uses charset name without any dashes in them
+			// (i.e. 'utf16le' instead of 'utf-16le').
+			const preferredCharset = config.charset.replace(/-/g, '').toLowerCase();
+			editor.setEncoding(preferredCharset);
+
 		}
 	});
 }


### PR DESCRIPTION
Although I can't find definitive documentations on Atom's API, it seems that by default Atom expects its encoding values to be without `-` in their names (i.e. `utf16le` instead of `utf-16le`) and its preferences view seems to support that as well:

![screen shot 2015-11-02 at 11 52 23 am](https://cloud.githubusercontent.com/assets/64360/10892921/e56a4a7a-815a-11e5-9e5c-2286ef6b28cb.png)

... which means normally one can't set Atom's encoding value to have `-` in them at all.

Calling `editor.setEncoding` with `-` in encoding names nevertheless seems to work (i.e. by default the editor's encoding is `utf8` and calling `editor.setEncoding('utf-8')` doesn't seems to break anything). But at the same time, that call trigger an buffer update/change operation that causes the editor to lose its current selection. So when opening files from search results view, the search terms would not be highlighted properly after the file is opened.

Removing `-` from the `charset` config before calling `editor.setEncoding` prevents that unnecessary editor update/change operation from happening and thus maintains the search term selection after opening the file from a search result view.

I also found another package, [encoding-selector](https://github.com/atom/encoding-selector) that does basically the same thing: https://github.com/atom/encoding-selector/blob/master/lib/main.coffee#L31 (the 1st level keys in its `encodings` hash -- i.e. `utf8`, `macroman`, etc. -- are used as parameter for `editor.setEncoding`).