### PR TITLE
Use # instead of ; for comments

### DIFF
--- a/settings/atom-editorconfig.cson
+++ b/settings/atom-editorconfig.cson
@@ -1,3 +1,3 @@
 '.source.ini':
   'editor':
-    'commentStart': '; '
+    'commentStart': '# '


### PR DESCRIPTION
Hi,

In all of the editorconfig examples I've ever seen (including the examples on [the official site](http://editorconfig.org/)), an octothorp (`#`) is used for comments instead of a semicolon (`;`). Therefore, as my changes suggest, I recommend the default commenting symbol be changed to `#`.

- [ ] created at least 1 spec to cover my changes,
  - Looking through your specs, I didn't see how this could be tested, or if it's even practical to test
- [X] `npm test`ed my code and it's green like an :green_apple:
  - Yep, still green! :green_apple:
- [X] adjusted the `readme.md`, if it was necessary
  - No changes to the README were necessary :+1: 
- [ ] would like to receive a virtual :beer: after that hard work!
  - I appreciate the offer, but no thanks ;)

Thanks for considering,
Caleb