### PR TITLE
Feature/support workspace properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function setWorkspaceConfig(editor) {
 		}
 
 		if (config.hasOwnProperty('insert_final_newline')) {
-			atom.config.set('whitespace.ensureSingleTrailingNewline', config.insert_final_newline)
+			atom.config.set('whitespace.ensureSingleTrailingNewline', config.insert_final_newline);
 		}
 	});
 }

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,8 @@ See the EditorConfig [documentation](http://editorconfig.org).
 - indent_size
 - charset *(supported values: `latin1`, `utf-8`, `utf-16be`, `utf-16le`)*
 - end_of_line *(supported values: `lf`, `crlf`)*
-
+- trim_trailing_whitespace
+- insert_final_newline
 
 ## Features
 

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,8 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true # doesn't work yet
-insert_final_newline = true # doesn't work yet
+trim_trailing_whitespace = true
+insert_final_newline = true
 ```
 
 

--- a/spec/base-spec.js
+++ b/spec/base-spec.js
@@ -49,4 +49,12 @@ describe('editorconfig', () => {
 	it('should have set the charset of the document to "utf8"', () => {
 		expect(textEditor.getEncoding()).toMatch('utf8');
 	});
+
+	it('should have set Remove trailing whitespace setting for whitespace package', () => {
+		expect(atom.config.get('whitespace.removeTrailingWhitespace')).toBeTruthy();
+	});
+
+	it('should have set Ensure single trailing newline setting for whitespace package', () => {
+		expect(atom.config.get('whitespace.ensureSingleTrailingNewline')).toBeTruthy();
+	});
 });

--- a/spec/fixtures/.editorconfig
+++ b/spec/fixtures/.editorconfig
@@ -5,3 +5,5 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
To make the maintainer's life easier, I...

- [x] created at least 1 spec to cover my changes,
- [x] `npm test`ed my code and it's green like an :green_apple:,
- [x] adjusted the `readme.md`, if it was necessary and
- [x] would like to receive a virtual :beer: after that hard work!

The main idea is setting "Workspace" package config when active pane is changed (cause https://github.com/atom/whitespace/issues/104 is still not implemented).
Also I've fixed an error message with promise, when opening settings tab.