### PR TITLE
Introduce a more strict grammar

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -38,12 +38,84 @@
     ]
   }
   {
+    'match': '(indent_style)\\s*(=)\\s*(tab|space)\\b'
     'captures':
       '1':
-        'name': 'keyword.other.definition.ini'
+        'name': 'keyword.other.definition.indent_style.ini'
       '2':
         'name': 'punctuation.separator.key-value.ini'
-    'match': '\\b([a-zA-Z0-9_.-]+)\\b\\s*(=)'
+      '3':
+        'name': 'variable.parameter.indent_style.ini'
+  }
+  {
+    'match': '(indent_size)\\s*(=)\\s*(\\d+|tab)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.indent_size.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.indent_size.ini'
+  }
+  {
+    'match': '(tab_width)\\s*(=)\\s*(\\d+)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.tab_width.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.tab_width.ini'
+  }
+  {
+    'match': '(end_of_line)\\s*(=)\\s*(lf|cr|crlf)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.end_of_line.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.end_of_line.ini'
+  }
+  {
+    'match': '(charset)\\s*(=)\\s*(latin1|utf-8|utf-16[bl]e)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.charset.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.charset.ini'
+  }
+  {
+    'match': '(trim_trailing_whitespace)\\s*(=)\\s*(true|false)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.trim_trailing_whitespace.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.trim_trailing_whitespace.ini'
+  }
+  {
+    'match': '(insert_final_newline)\\s*(=)\\s*(true|false)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.insert_final_newline.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.insert_final_newline.ini'
+  }
+  {
+    'match': '(root)\\s*(=)\\s*(true|false)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.other.definition.root.ini'
+      '2':
+        'name': 'punctuation.separator.key-value.ini'
+      '3':
+        'name': 'variable.parameter.root.ini'
   }
   {
     'captures':

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -38,7 +38,7 @@
     ]
   }
   {
-    'match': '(indent_style)\\s*(=)\\s*(tab|space)\\b'
+    'match': '(indent_style)\\s*(=)\\s*([Tt][Aa][Bb]|[Ss][Pp][Aa][Cc][Ee])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.indent_style.ini'
@@ -48,7 +48,7 @@
         'name': 'variable.parameter.indent_style.ini'
   }
   {
-    'match': '(indent_size)\\s*(=)\\s*(\\d+|tab)\\b'
+    'match': '(indent_size)\\s*(=)\\s*(\\d+|[Tt][Aa][Bb])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.indent_size.ini'
@@ -68,7 +68,7 @@
         'name': 'variable.parameter.tab_width.ini'
   }
   {
-    'match': '(end_of_line)\\s*(=)\\s*(lf|cr|crlf)\\b'
+    'match': '(end_of_line)\\s*(=)\\s*([Ll][Ff]|[Cc][Rr]|[Cc][Rr][Ll][Ff])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.end_of_line.ini'
@@ -78,7 +78,7 @@
         'name': 'variable.parameter.end_of_line.ini'
   }
   {
-    'match': '(charset)\\s*(=)\\s*(latin1|utf-8|utf-16[bl]e)\\b'
+    'match': '(charset)\\s*(=)\\s*([Ll][Aa][Tt][Ii][Nn]1|[Uu][Tt][Ff]-8|[Uu][Tt][Ff]-16[BLbl][Ee])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.charset.ini'
@@ -88,7 +88,7 @@
         'name': 'variable.parameter.charset.ini'
   }
   {
-    'match': '(trim_trailing_whitespace)\\s*(=)\\s*(true|false)\\b'
+    'match': '(trim_trailing_whitespace)\\s*(=)\\s*([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.trim_trailing_whitespace.ini'
@@ -98,7 +98,7 @@
         'name': 'variable.parameter.trim_trailing_whitespace.ini'
   }
   {
-    'match': '(insert_final_newline)\\s*(=)\\s*(true|false)\\b'
+    'match': '(insert_final_newline)\\s*(=)\\s*([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.insert_final_newline.ini'
@@ -108,7 +108,7 @@
         'name': 'variable.parameter.insert_final_newline.ini'
   }
   {
-    'match': '(root)\\s*(=)\\s*(true|false)\\b'
+    'match': '(root)\\s*(=)\\s*([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])\\b'
     'captures':
       '1':
         'name': 'keyword.other.definition.root.ini'


### PR DESCRIPTION
To make the maintainer's life easier, I...

- [ ] created at least 1 spec to cover my changes,
  + I'm afraid I have no experience of writing a spec, so I don't know how to. I don't think my commit is big enough to create a corresponding spec, but if it's really needed and someone is kind to make one, he or she is more than welcome!
- [x] `npm test`ed my code and it's green like an :green_apple:,
  + Tests passed! :sparkles:
- [x] adjusted the `readme.md`, if it was necessary and
  + No need to change `readme.md`, I guess.
- [ ] would like to receive get a :beer: or :coffee: after that hard work!
  + No thanks, but I appreciate your kindness! :+1:

The current grammar is quite rough and it matches to anything in the form of `key = value`. This PR disallows matching to such malformed settings and only highlights valid ones listed in [EditorConfig's Wiki](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties). This will visually help users notice invalid lines (e.g., they made a typo or didn't remember the correct key/value name).

P.S. The default `indent_style` is set to `tab` in [`.editorconfig` of this repo](https://github.com/sindresorhus/atom-editorconfig/blob/v1.5.4/.editorconfig#L4), but `grammars/ini.cson` uses 2-space indentation. I respected the consistency in a file.