### PR TITLE
Implement max_line_length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = off
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -13,7 +13,7 @@ Every issue assigned is being worked on, seriously. Issues may be dedicated to m
 
 Let us know that you'd like to contribute in an issue - we will then assign you to it, to show everybody involved that this issue is being worked on.
 
-We're also happy to help you taking the first hurdles on your way to a successful contributor! So if you have any questions on how to help - get in touch! :checkered_flag:
+We're also happy to help you taking the first hurdles on your way to a successful contributor! So if you have any questions on how to help - get in touch!
 
 ### :sparkles: Fork it
 

--- a/commands/show.js
+++ b/commands/show.js
@@ -15,6 +15,7 @@ ${props.messages.reduce((prev, curr) => {
 |\`indent_size\`/ \`tab_width\`|\`${props.tab_width}\`|
 |\`insert_final_newline\`|\`${props.insert_final_newline}\`|
 |\`trim_trailing_whitespace\`|\`${props.trim_trailing_whitespace}\`|
+|\`max_line_length\` *(experimental)*|\`${props.max_line_length}\`|
 
 _(auto: atom-editorconfig is not influencing that behavior. A full description of the properties can be found on editorconfig.org.)_
 
@@ -45,7 +46,9 @@ const init = () => {
 			// eslint-disable-next-line camelcase
 			insert_final_newline: settings.insert_final_newline,
 			// eslint-disable-next-line camelcase
-			trim_trailing_whitespace: settings.trim_trailing_whitespace
+			trim_trailing_whitespace: settings.trim_trailing_whitespace,
+			// eslint-disable-next-line camelcase
+			max_line_length: settings.max_line_length
 		};
 
 		const notificationOptions = {

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function initializeTextBuffer(buffer) {
 					if (settings.tab_width === 'auto') {
 						editorParams.tabLength = atom.config.get('editor.tabLength', configOptions);
 					} else {
-						editorParams.softTabs = settings.tab_width;
+						editorParams.tabLength = settings.tab_width;
 					}
 
 					if (settings.charset === 'auto') {

--- a/lib/wrapguide-view.js
+++ b/lib/wrapguide-view.js
@@ -1,0 +1,56 @@
+/** @babel */
+
+class EditorconfigWrapGuideElement extends HTMLDivElement { // eslint-disable-line no-undef
+	initialize(editor, editorElement) {
+		this.classList.add('ecfg-wrap-guide');
+		this.editorElement = editorElement;
+		this.editor = editor;
+		this.visible = true;
+
+		this.attachToLines();
+		this.update();
+	}
+
+	attachToLines() {
+		const editorElement = this.editorElement;
+
+		if (editorElement &&
+			editorElement.rootElement) {
+			const lines = editorElement.rootElement.querySelector('.lines');
+			if (lines) {
+				lines.appendChild(this);
+			}
+		}
+	}
+
+	update() {
+		const editorElement = this.editorElement;
+		// eslint-disable-next-line camelcase
+		const max_line_length = this.editor.getBuffer().editorconfig.settings.max_line_length;
+
+		if (max_line_length === 'auto') { // eslint-disable-line camelcase
+			this.style.display = 'none';
+			this.visible = false;
+		} else {
+			// eslint-disable-next-line camelcase
+			let columnWidth = editorElement.getDefaultCharacterWidth() * max_line_length;
+			if (editorElement.logicalDisplayBuffer) {
+				columnWidth -= editorElement.getScrollLeft();
+			} else {
+				columnWidth -= this.editor.getScrollLeft();
+			}
+			this.style.left = `${Math.round(columnWidth)}px`;
+			this.style.display = 'block';
+			this.visible = true;
+		}
+	}
+
+	isVisible() {
+		return this.visible === true;
+	}
+}
+
+module.exports = document.registerElement('ecfg-wrap-guide', {
+	extends: 'div',
+	prototype: EditorconfigWrapGuideElement.prototype
+});

--- a/styles/atom-editorconfig.less
+++ b/styles/atom-editorconfig.less
@@ -1,8 +1,19 @@
 @import "ui-variables";
+@import "syntax-variables";
 
 #aec-status-bar-tile {
 	cursor: pointer;
 	box-sizing: border-box;
+}
+
+atom-text-editor::shadow .ecfg-wrap-guide {
+	height: 100%;
+	width: 1px;
+	z-index: 3;
+	position: absolute;
+	top: 0;
+	background-color: @syntax-wrap-guide-color;
+	-webkit-transform: translateZ(0);
 }
 
 @font-face {


### PR DESCRIPTION
This feature is still **experimental** since this is the first time we're going to automagically de/activate packages (in this case 'wrap-guide') in the background.

If this is working in a long term, we will tackle the whitespace package, too.
## I Need Your Help

by testing this implementation. How? Go on...
1. clone `git@github.com:florianb/atom-editorconfig.git` and checkout the `max_line_length`-branch.
2. link the repository (with `apm link`)
3. watch this branch for updates and please post any issues regarding the wrap-guide behavior.

After this is merged you need to `apm unlink` the directory to rely on the main package-line again.. 

💝 
