### PR TITLE
Update deprecated ::shadow selector

### DIFF
--- a/styles/atom-editorconfig.less
+++ b/styles/atom-editorconfig.less
@@ -31,4 +31,4 @@ atom-text-editor.editor .ecfg-wrap-guide {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.aec-icon-mouse:before{content:'\0041';}
+.aec-icon-mouse:before { content:'\0041'; }

--- a/styles/atom-editorconfig.less
+++ b/styles/atom-editorconfig.less
@@ -6,7 +6,7 @@
 	box-sizing: border-box;
 }
 
-atom-text-editor::shadow .ecfg-wrap-guide {
+atom-text-editor.editor .ecfg-wrap-guide {
 	height: 100%;
 	width: 1px;
 	z-index: 3;
@@ -22,6 +22,7 @@ atom-text-editor::shadow .ecfg-wrap-guide {
 	font-weight: normal;
 	font-style: normal;
 }
+
 [class*='aec-icon'] {
 	font-family: 'Editorconfig';
 	font-style: normal;
@@ -29,4 +30,5 @@ atom-text-editor::shadow .ecfg-wrap-guide {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
+
 .aec-icon-mouse:before{content:'\0041';}


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

- `atom-text-editor::shadow .ecfg-wrap-guide` => `atom-text-editor.editor .ecfg-wrap-guide`

Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.


