### PR TITLE
Exclude unnecessary files from distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 *.js text eol=lf
 /.github/ export-ignore
 /yarn.lock export-ignore
-/fievel-mousekewitz48.gif export-ignore
+/*.gif export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 * text=auto
 *.js text eol=lf
+/.github/ export-ignore
+/yarn.lock export-ignore
+/fievel-mousekewitz48.gif export-ignore


### PR DESCRIPTION
Follow-up of #152, which I submitted before learning there's a more efficient way to exclude files in package tarballs (thanks @gorriecoe).

This PR knocks ~1.6 MBs off the package's total size, ensuring updates are downloaded to users quicker.