### PR TITLE
Increase the strength of the selector

### DIFF
--- a/styles/atom-editorconfig.less
+++ b/styles/atom-editorconfig.less
@@ -25,7 +25,8 @@ atom-text-editor {
 	font-style: normal;
 }
 
-[class*='aec-icon'] {
+[class*='aec-icon'],
+[class*='aec-icon']:before {
 	font-family: 'Editorconfig';
 	font-style: normal;
 	font-weight: normal;


### PR DESCRIPTION
Increase the strength of the selector so custom themes display the mouse instead of the 'A'.  Alternatively you could use `.aec-icon-mouse { ...` but I assume you want broad selector for additional icons.