### PR TITLE
check whether container exists before appending icon

### DIFF
--- a/lib/statustile-view.js
+++ b/lib/statustile-view.js
@@ -30,9 +30,13 @@ export const removeIcon = () => {
 	}
 };
 
+export const containerExists = () => {
+	return getContainer() !== null;
+};
+
 const displayIcon = state => {
 	const icon = getIcon() || createIcon(state);
-	if (icon.parentNode === null) {
+	if (icon.parentNode === null && containerExists()) {
 		getContainer().appendChild(icon);
 	} else {
 		icon.className = getIconClass(state);
@@ -57,8 +61,4 @@ export const createContainer = () => {
 	div.className = 'inline-block';
 
 	return div;
-};
-
-export const containerExists = () => {
-	return getContainer() !== null;
 };

--- a/spec/issue-178-spec.js
+++ b/spec/issue-178-spec.js
@@ -1,0 +1,24 @@
+/** @babel */
+/* eslint-env jasmine, atomtest */
+
+/*
+  This file contains verifying specs for:
+  https://github.com/sindresorhus/atom-editorconfig/issues/178
+*/
+
+import {updateIcon} from '../lib/statustile-view';
+
+describe('editorconfig with disabled status-bar package', () => {
+	beforeEach(() => {
+		waitsForPromise(() =>
+			Promise.all([
+				atom.packages.activatePackage('editorconfig')
+			]));
+	});
+
+	describe('when opening a file', () => {
+		it('shouldn\'t throw an exception', () => {
+			expect(() => updateIcon('warning')).not.toThrow();
+		});
+	});
+});

--- a/spec/issue-178-spec.js
+++ b/spec/issue-178-spec.js
@@ -16,7 +16,7 @@ describe('editorconfig with disabled status-bar package', () => {
 			]));
 	});
 
-	describe('when opening a file', () => {
+	describe('when updating the status bar icon', () => {
 		it('shouldn\'t throw an exception', () => {
 			expect(() => updateIcon('warning')).not.toThrow();
 		});


### PR DESCRIPTION
This fixes an uncaught exception if the status-bar does not exist due to the entire package being disabled

fixes #178 

To make the maintainer's life easier, I...

- [x] created at least 1 spec to cover my changes
- [x] `npm test`ed my code and it's green like an :green_apple: