### PR TITLE
Replace 'auto' with 'unset' per the new spec

### DIFF
--- a/commands/fix.js
+++ b/commands/fix.js
@@ -19,7 +19,7 @@ const init = () => {
 	};
 
 	// Fix end_of_line, if necessary
-	if (settings.end_of_line !== 'auto') {
+	if (settings.end_of_line !== 'unset') {
 		const lastRow = buffer.getLastRow();
 		for (let i = 0; i < lastRow; i++) {
 			if (buffer.lineEndingForRow(i) !== settings.end_of_line &&
@@ -38,7 +38,7 @@ const init = () => {
 	}
 
 	// Fix indent_style, if necessary
-	if (settings.indent_style !== 'auto') {
+	if (settings.indent_style !== 'unset') {
 		const spaceChar = {true: ' ', false: '\\t'};
 		const tabLength = editor.getTabLength();
 		// Match only malformed (containing at least one wrong tab-char) lines

--- a/commands/show.js
+++ b/commands/show.js
@@ -17,7 +17,7 @@ ${props.messages.reduce((prev, curr) => {
 |\`trim_trailing_whitespace\`|\`${props.trim_trailing_whitespace}\`|
 |\`max_line_length\`|\`${props.max_line_length}\`|
 
-_(auto: atom-editorconfig is not influencing its behavior. A full description of all properties can be found on editorconfig.org.)_
+_(unset: atom-editorconfig is not influencing its behavior. A full description of all properties can be found on editorconfig.org.)_
 
 ${(props.filename !== undefined && props.filename) || ''}
 `;

--- a/grammars/editorconfig.json
+++ b/grammars/editorconfig.json
@@ -41,7 +41,7 @@
       "name": "comment.line.semicolon.editorconfig"
     }]
   }, {
-    "match": "(?i)(indent_style)\\s*(=)\\s*(tab|space)\\b",
+    "match": "(?i)(indent_style)\\s*(=)\\s*(tab|space|unset)\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"
@@ -54,7 +54,7 @@
       }
     }
   }, {
-    "match": "(?i)(indent_size)\\s*(=)\\s*(?:(\\d+)|(tab))\\b",
+    "match": "(?i)(indent_size)\\s*(=)\\s*(?:(\\d+)|(tab|unset))\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"
@@ -70,7 +70,7 @@
       }
     }
   }, {
-    "match": "(?i)(tab_width)\\s*(=)\\s*(\\d+)\\b",
+    "match": "(?i)(tab_width)\\s*(=)\\s*(?:(\\d+)|(unset))\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"
@@ -80,10 +80,13 @@
       },
       "3": {
         "name": "constant.numeric.$1.editorconfig"
+      },
+      "4": {
+        "name": "constant.language.$1.editorconfig"
       }
     }
   }, {
-    "match": "(?i)(max_line_length)\\s*(=)\\s*(?:(\\d+)|(Off))\\b",
+    "match": "(?i)(max_line_length)\\s*(=)\\s*(?:(\\d+)|(off)|(unset))\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"
@@ -96,10 +99,13 @@
       },
       "4": {
         "name": "constant.language.boolean.false.editorconfig"
+      },
+      "5": {
+        "name": "constant.language.$1.editorconfig"
       }
     }
   }, {
-    "match": "(?i)(end_of_line)\\s*(=)\\s*(LF|CR|CRLF)\\b",
+    "match": "(?i)(end_of_line)\\s*(=)\\s*(LF|CR|CRLF|unset)\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"
@@ -112,7 +118,7 @@
       }
     }
   }, {
-    "match": "(?i)(charset)\\s*(=)\\s*(Latin1|UTF-8|UTF-16[BL]E)\\b",
+    "match": "(?i)(charset)\\s*(=)\\s*(Latin1|UTF-8|UTF-16[BL]E|unset)\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"
@@ -125,7 +131,23 @@
       }
     }
   }, {
-    "match": "(?i)(insert_final_newline|root|trim_trailing_whitespace)\\s*(=)\\s*(true|false)\\b",
+    "match": "(?i)(insert_final_newline|trim_trailing_whitespace)\\s*(=)\\s*(?:(true|false)|(unset))\\b",
+    "captures": {
+      "1": {
+        "name": "keyword.other.definition.$1.editorconfig"
+      },
+      "2": {
+        "name": "punctuation.separator.key-value.editorconfig"
+      },
+      "3": {
+        "name": "constant.language.boolean.${3:/downcase}.editorconfig"
+      },
+      "4": {
+        "name": "constant.language.$1.editorconfig"
+      }
+    }
+  }, {
+    "match": "(?i)(root)\\s*(=)\\s*(true|false)\\b",
     "captures": {
       "1": {
         "name": "keyword.other.definition.$1.editorconfig"

--- a/index.js
+++ b/index.js
@@ -28,13 +28,13 @@ function initializeTextBuffer(buffer) {
 			state: 'subtle',
 			settings: {
 				/* eslint-disable camelcase */
-				trim_trailing_whitespace: 'auto',
-				insert_final_newline: 'auto',
-				max_line_length: 'auto',
-				end_of_line: 'auto',
-				indent_style: 'auto',
-				tab_width: 'auto',
-				charset: 'auto'
+				trim_trailing_whitespace: 'unset',
+				insert_final_newline: 'unset',
+				max_line_length: 'unset',
+				end_of_line: 'unset',
+				indent_style: 'unset',
+				tab_width: 'unset',
+				charset: 'unset'
 				/* eslint-enable camelcase */
 			},
 
@@ -56,7 +56,7 @@ function initializeTextBuffer(buffer) {
 				const settings = this.settings;
 
 				if (editor && editor.getBuffer() === buffer) {
-					if (settings.indent_style === 'auto') {
+					if (settings.indent_style === 'unset') {
 						const usesSoftTabs = editor.usesSoftTabs();
 						if (usesSoftTabs === undefined) {
 							editor.setSoftTabs(atom.config.get('editor.softTabs', configOptions));
@@ -67,13 +67,13 @@ function initializeTextBuffer(buffer) {
 						editor.setSoftTabs(settings.indent_style === 'space');
 					}
 
-					if (settings.tab_width === 'auto') {
+					if (settings.tab_width === 'unset') {
 						editor.setTabLength(atom.config.get('editor.tabLength', configOptions));
 					} else {
 						editor.setTabLength(settings.tab_width);
 					}
 
-					if (settings.charset === 'auto') {
+					if (settings.charset === 'unset') {
 						buffer.setEncoding(atom.config.get('core.fileEncoding', configOptions));
 					} else {
 						buffer.setEncoding(settings.charset);
@@ -81,7 +81,7 @@ function initializeTextBuffer(buffer) {
 
 					// Max_line_length-settings
 					const editorParams = {};
-					if (settings.max_line_length === 'auto') {
+					if (settings.max_line_length === 'unset') {
 						editorParams.preferredLineLength =
 							atom.config.get('editor.preferredLineLength', configOptions);
 					} else {
@@ -109,7 +109,7 @@ function initializeTextBuffer(buffer) {
 						wrapGuide.updateGuide();
 					}
 
-					if (settings.end_of_line !== 'auto') {
+					if (settings.end_of_line !== 'unset') {
 						buffer.setPreferredLineEnding(settings.end_of_line);
 					}
 				}
@@ -129,7 +129,7 @@ function initializeTextBuffer(buffer) {
 					});
 				}
 
-				if (settings.insert_final_newline !== 'auto') {
+				if (settings.insert_final_newline !== 'unset') {
 					const lastRow = buffer.getLineCount() - 1;
 
 					if (buffer.isRowBlank(lastRow)) {
@@ -200,33 +200,33 @@ function observeTextEditor(editor) {
 		settings.trim_trailing_whitespace = ('trim_trailing_whitespace' in config) &&
 			typeof config.trim_trailing_whitespace === 'boolean' ?
 			config.trim_trailing_whitespace === true :
-			'auto';
+			'unset';
 
 		settings.insert_final_newline = ('insert_final_newline' in config) &&
 			typeof config.insert_final_newline === 'boolean' ?
 			config.insert_final_newline === true :
-			'auto';
+			'unset';
 
 		settings.indent_style = (('indent_style' in config) &&
 			config.indent_style.search(/^(space|tab)$/) > -1) ?
 			config.indent_style :
-			'auto';
+			'unset';
 
-		settings.end_of_line = lineEndings[config.end_of_line] || 'auto';
+		settings.end_of_line = lineEndings[config.end_of_line] || 'unset';
 
 		settings.tab_width = parseInt(config.indent_size || config.tab_width, 10);
 		if (isNaN(settings.tab_width) || settings.tab_width <= 0) {
-			settings.tab_width = 'auto';
+			settings.tab_width = 'unset';
 		}
 
 		settings.max_line_length = parseInt(config.max_line_length, 10);
 		if (isNaN(settings.max_line_length) || settings.max_line_length <= 0) {
-			settings.max_line_length = 'auto';
+			settings.max_line_length = 'unset';
 		}
 
 		settings.charset = ('charset' in config) ?
 			config.charset.replace(/-/g, '').toLowerCase() :
-			'auto';
+			'unset';
 
 		/* eslint-enable camelcase */
 

--- a/lib/checklist.js
+++ b/lib/checklist.js
@@ -9,7 +9,7 @@ const testPackage = (ecfg, check) => {
 	if (check.package !== undefined &&
 		atom.packages.isPackageActive(check.package) === true &&
 		Array.isArray(check.properties) === true) {
-		const props = check.properties.filter(p => ecfg.settings[p] !== 'auto');
+		const props = check.properties.filter(p => ecfg.settings[p] !== 'unset');
 		if (props.length > 0) {
 			return `**${check.package}:** It is possible that the
 			"${check.package}"-package prevents the following
@@ -27,7 +27,7 @@ const CHECKLIST = [
 		statcon: 1,
 		test: ecfg => {
 			return Object.keys(ecfg.settings).reduce((prev, curr) => {
-				return ecfg.settings[curr] !== 'auto' || prev;
+				return ecfg.settings[curr] !== 'unset' || prev;
 			}, false);
 		}
 	},
@@ -40,7 +40,7 @@ const CHECKLIST = [
 	{
 		statcon: 4,
 		test: ecfg => {
-			if (ecfg.settings.indent_style !== 'auto' &&
+			if (ecfg.settings.indent_style !== 'unset' &&
 				atom.packages.isPackageActive('tabs-to-spaces') === true) {
 				const onSave = atom.config.get(
 					'tabs-to-spaces.onSave',
@@ -63,7 +63,7 @@ const CHECKLIST = [
 	{
 		statcon: 4,
 		test: ecfg => {
-			if (ecfg.settings.indent_style !== 'auto' &&
+			if (ecfg.settings.indent_style !== 'unset' &&
 				atom.config.get('editor.tabType') !== 'auto') {
 				const tabType = atom.config.get('editor.tabType');
 				return `**Tab Type:** Your editor's configuration setting "Tab Type"

--- a/lib/wrapguide-interceptor.js
+++ b/lib/wrapguide-interceptor.js
@@ -4,7 +4,7 @@ module.exports = {
 		const editor = this.editor;
 		const maxLineLength = this.editorconfig.settings.max_line_length;
 
-		if (maxLineLength === 'auto') {
+		if (maxLineLength === 'unset') {
 			return this.getNativeGuideColumn(editor.getPath(), editor.getGrammar().scopeName);
 		}
 
@@ -16,7 +16,7 @@ module.exports = {
 		const maxLineLength = this.editorconfig.settings.max_line_length;
 		const multiGuides = this.getNativeGuidesColumns(editor.getPath(), editor.getGrammar().scopeName);
 
-		if (maxLineLength === 'auto') {
+		if (maxLineLength === 'unset') {
 			return multiGuides;
 		} else if (Array.isArray(multiGuides)) {
 			return multiGuides.filter(col => col < maxLineLength).concat([maxLineLength]);

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ See the EditorConfig [documentation](http://editorconfig.org) for a detailed des
 - `insert_final_newline` *(supported values: `true`, `false`; Setting this to `false` strips final newlines)*
 - `max_line_length`
 
-> :bulb: Any malformed or missing property falls back to `auto` which leaves the control to Atom.
+> :bulb: Any malformed or missing property falls back to `unset` which leaves the control to Atom.
 
 ## EditorConfig commands
 

--- a/spec/fixtures/iss193/.editorconfig
+++ b/spec/fixtures/iss193/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+end_of_line = unset
+charset = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+max_line_length = unset

--- a/spec/iss128-spec.js
+++ b/spec/iss128-spec.js
@@ -57,7 +57,7 @@ describe('editorconfig', () => {
 	describe('Atom with disabled wrap-guide', () => {
 		beforeEach(() => {
 			Object.assign(textEditor.getBuffer().editorconfig.settings, {
-				max_line_length: 'auto' // eslint-disable-line camelcase
+				max_line_length: 'unset' // eslint-disable-line camelcase
 			});
 		});
 

--- a/spec/iss132-spec.js
+++ b/spec/iss132-spec.js
@@ -63,9 +63,9 @@ describe('editorconfig', () => {
 	});
 
 	describe('EditorConfig', () => {
-		it('should default zero indent_size and tab_width to auto', () => {
-			expect(textEditors[0].getBuffer().editorconfig.settings.tab_width).toEqual('auto');
-			expect(textEditors[1].getBuffer().editorconfig.settings.tab_width).toEqual('auto');
+		it('should default zero indent_size and tab_width to unset', () => {
+			expect(textEditors[0].getBuffer().editorconfig.settings.tab_width).toEqual('unset');
+			expect(textEditors[1].getBuffer().editorconfig.settings.tab_width).toEqual('unset');
 		});
 	});
 });

--- a/spec/iss148-spec.js
+++ b/spec/iss148-spec.js
@@ -67,7 +67,7 @@ describe('editorconfig', () => {
 			ecfg.applySettings();
 			expect(wgCount()).toBe(1);
 			// eslint-disable-next-line camelcase
-			ecfg.settings.max_line_length = 'auto';
+			ecfg.settings.max_line_length = 'unset';
 			ecfg.applySettings();
 			expect(wgCount()).toBe(1);
 			// eslint-disable-next-line camelcase
@@ -75,7 +75,7 @@ describe('editorconfig', () => {
 			ecfg.applySettings();
 			expect(wgCount()).toBe(1);
 			// eslint-disable-next-line camelcase
-			ecfg.settings.max_line_length = 'auto';
+			ecfg.settings.max_line_length = 'unset';
 			ecfg.applySettings();
 			expect(wgCount()).toBe(1);
 		});

--- a/spec/iss157-spec.js
+++ b/spec/iss157-spec.js
@@ -54,12 +54,12 @@ describe('editorconfig', () => {
 	});
 
 	describe('EditorConfig', () => {
-		it('should consult editor.usesSoftTabs in case tabType is set to auto', () => {
+		it('should consult editor.usesSoftTabs in case tabType\'s value is `unset`', () => {
 			const configOptions = {scope: textEditor.getRootScopeDescriptor()};
 			const ecfg = textEditor.getBuffer().editorconfig;
 
 			// eslint-disable-next-line camelcase
-			ecfg.settings.indent_style = 'auto';
+			ecfg.settings.indent_style = 'unset';
 
 			atom.config.set('editor.softTabs', true, configOptions);
 			textEditor.setText(snippetWithHardTabs);

--- a/spec/iss193-spec.js
+++ b/spec/iss193-spec.js
@@ -3,9 +3,10 @@
 
 /*
   This file contains verifying specs for:
-  https://github.com/sindresorhus/atom-editorconfig/issues/139
+  https://github.com/sindresorhus/atom-editorconfig/issues/193
 
-  If the max_line_length is set to 0 tha wrapGuide is set to 1.
+  If any property values are the string 'unset', they the resulting settings
+	should also be the value 'unset'.
 */
 
 import fs from 'fs';
@@ -49,8 +50,16 @@ describe('editorconfig', () => {
 	});
 
 	describe('EditorConfig', () => {
-		it('should default zero max_line_length to unset', () => {
-			expect(textEditors[0].getBuffer().editorconfig.settings.max_line_length).toEqual('unset');
+		it('unset properties should remain unset, since it is the fallback', () => {
+			const settings = textEditors[0].getBuffer().editorconfig.settings;
+
+			expect(settings.end_of_line).toEqual('unset');
+			expect(settings.charset).toEqual('unset');
+			expect(settings.indent_style).toEqual('unset');
+			expect(settings.tab_width).toEqual('unset');
+			expect(settings.insert_final_newline).toEqual('unset');
+			expect(settings.trim_trailing_whitespace).toEqual('unset');
+			expect(settings.max_line_length).toEqual('unset');
 		});
 	});
 });

--- a/spec/wrapguide-interceptor-spec.js
+++ b/spec/wrapguide-interceptor-spec.js
@@ -11,7 +11,7 @@ const editorStub = {
 	nativeGuidesColumns: [30, 60, 90, 120],
 	editorconfig: {
 		settings: {
-			max_line_length: 'auto' // eslint-disable-line camelcase
+			max_line_length: 'unset' // eslint-disable-line camelcase
 		}
 	},
 	getNativeGuidesColumns() {
@@ -33,7 +33,7 @@ describe('wrapGuideInterceptor.getNativeGuidesColumns()', () => {
 		editor = Object.assign({}, editorStub);
 	});
 
-	it('should pass guidesColums if `max_line_length` is `auto`', () => {
+	it('should pass guidesColums if `max_line_length` is `unset`', () => {
 		expect(editor.getGuidesColumns()).toEqual(editor.nativeGuidesColumns);
 	});
 


### PR DESCRIPTION
To make the maintainer's life easier, I...

- [x] created at least 1 spec to cover my changes,
- [x] `npm test`ed my code and it's green like an :green_apple:,
- [x] adjusted the `readme.md`, if it was necessary and
- [x] would like to receive get a :beer: ~~or :coffee:~~ after that hard work!

Resolves https://github.com/sindresorhus/atom-editorconfig/issues/193

I updated the grammar and changed all relevant instances of `auto` to `unset` per the new terminology. If you search the repo, there are a few instances of `auto` left, but those referring to Atom's built in 'tab type' setting. It made more sense to update every instance of `auto` to `unset` to prevent conflicting terminology throughout the repo, although it isn't necessary to do so.

I also added a new test, to show that when any of the properties are `unset`, the settings in the plugin will match that.