### PR TITLE
[WIP] Implement the whitespace.suppressor service

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,6 +274,20 @@ const deactivate = () => {
 	statusTile.removeIcon();
 };
 
+const provideWhitespaceSuppressor = () => {
+	return {
+		shouldSuppressRemoveTrailingWhitespace(editor) {
+			const settings = editor.getBuffer().editorconfig.settings;
+			return settings.trim_trailing_whitespace !== 'unset';
+		},
+
+		shouldSuppressEnsureSingleTrailingNewline(editor) {
+			const settings = editor.getBuffer().editorconfig.settings;
+			return settings.insert_final_newline !== 'unset';
+		}
+	};
+};
+
 // Apply the statusbar icon-container
 // The icon will be applied if needed
 const consumeStatusBar = statusBar => {
@@ -285,4 +299,4 @@ const consumeStatusBar = statusBar => {
 	}
 };
 
-export default {activate, deactivate, consumeStatusBar};
+export default {activate, deactivate, provideWhitespaceSuppressor, consumeStatusBar};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
       "import/prefer-default-export": "off"
     }
   },
+  "providedServices": {
+    "whitespace.suppressor": {
+      "versions": {
+        "1.0.0": "provideWhitespaceSuppressor"
+      }
+    }
+  },
   "consumedServices": {
     "status-bar": {
       "versions": {


### PR DESCRIPTION
Accompanying PR for https://github.com/atom/whitespace/pull/161. No specs for now, I'm only opening this to garner attention for the whitespace package PR. This won't do anything without it.

This allows editorconfig to suppress the automatic transformations of the core Atom whitespace package, removing the need to disable the whitespace package and allowing it to work when the relevent editorconfig properties are unset.

### TODO
- [ ] Suppress the warning in `checklist.js` for the whitespace package when `provideWhitespaceSuppressor` has been called.

### Related
https://github.com/sindresorhus/atom-editorconfig/issues/105
https://github.com/sindresorhus/atom-editorconfig/issues/159

### To make the maintainer's life easier, I...

- [ ] created at least 1 spec to cover my changes,
- [ ] `npm test`ed my code and it's green like an :green_apple:,
- [ ] adjusted the `readme.md`, if it was necessary and
- [ ] would like to receive get a :beer: or :coffee: after that hard work!
