### PR TITLE
allow ability to disable/persist notifications

### DIFF
--- a/commands/fix.js
+++ b/commands/fix.js
@@ -79,8 +79,12 @@ const init = () => {
 		changesInTotal += fixedProperties[k];
 	});
 
+	if (atom.config.get('editorconfig.disableNotifications')) {
+		return;
+	}
+
 	// Prepare notification & save changes
-	const notificationOptions = {dismissable: true};
+	const notificationOptions = {dismissable: atom.config.get('editorconfig.persistNotifications')};
 	if (changesInTotal > 0) {
 		const styleName = softTabs === true ? 'Tab(s)' : 'Space(s)';
 

--- a/index.js
+++ b/index.js
@@ -285,4 +285,15 @@ const consumeStatusBar = statusBar => {
 	}
 };
 
-export default {activate, deactivate, consumeStatusBar};
+const config = {
+	disableNotifications: {
+		type: 'boolean',
+		default: false
+	},
+	persistNotifications: {
+		type: 'boolean',
+		default: true
+	}
+};
+
+export default {activate, deactivate, consumeStatusBar, config};

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,11 @@ See the EditorConfig [documentation](http://editorconfig.org) for a detailed des
 - Recognizes if you save any `.editorconfig` file and reapplies all settings to **all** opened editor-panes
 
 
+## Settings
+
+- editorconfig.disableNotifications (default: `false`) disables notifications
+- editorconfig.persistNotifications (default: `true`) persists the notifications
+
 ## Example file
 
 ```ini


### PR DESCRIPTION
question: I don't see any reason why `persistNotifications` should be true. the user has to manually click on the notification to remove it. is this desired default behaviour?

EDIT: also the tests are totally broken. I get from 14-19 failures each try. also, I don't know how I would go about testing this configuration, nor do I think it's really necessary

---

To make the maintainer's life easier, I...

- [ ] created at least 1 spec to cover my changes,
- [x] `npm test`ed my code and it returns lots of failures regardless
- [x] adjusted the `readme.md`, if it was necessary and
- [ ] would like to receive get a :beer: or :coffee: after that hard work!



