### PR TITLE
Remove cursor:pointer from status bar tile

### DIFF
--- a/styles/atom-editorconfig.less
+++ b/styles/atom-editorconfig.less
@@ -2,7 +2,6 @@
 @import "syntax-variables";
 
 #aec-status-bar-tile {
-	cursor: pointer;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
This changes makes the status bar tile conform to the standard set by the default tiles.
![atom editorconfig status bar](https://user-images.githubusercontent.com/2564094/36508311-3b50a300-1711-11e8-8f73-b9a664d2cd7e.gif)
