### PR TITLE
Make sure the editor has a buffer before using it

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,8 +247,8 @@ function reapplyEditorconfig() {
 // Reapplies the settings immediately after changing the focus to a new pane
 function observeActivePaneItem(editor) {
 	if (editor && editor.constructor.name === 'TextEditor') {
-		if (editor.getBuffer().editorconfig) {
-			editor.getBuffer().editorconfig.applySettings();
+		if (editor.buffer && editor.buffer.editorconfig) {
+			editor.buffer.editorconfig.applySettings();
 		}
 	} else {
 		statusTile.removeIcon();


### PR DESCRIPTION
Fixes sindresorhus/atom-editorconfig#222

To make the maintainer's life easier, I...

- [ ] `npm test`ed my code and it's green like an :green_apple:,
  - None of the tests work and my changes didn't change that
- [X] adjusted the `readme.md`, if it was necessary