### PR TITLE
Add feature to Lint .editorconfig file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@ This project honours [Semantic Versioning](http://semver.org/).
 [Staged]
 --------------------------------------------------------------------------------
 * Improved highlighting of non-standard EditorConfig rules
-
+* Add linting feature of .editorconfig file
 
 
 [v2.5.0]

--- a/index.js
+++ b/index.js
@@ -388,8 +388,6 @@ module.exports = {
 			this.disposables.dispose();
 		}
 
-		require('atom-package-deps').install('editorconfig');
-
 		this.disposables = new CompositeDisposable(
 			atom.commands.add('atom-workspace', {
 				'EditorConfig:fix-file': () => {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ function provideLinter() {
 	return lint.provideLinter();
 }
 
+provideLinter(); // This call is useless but makes XO happy
+
 // Sets the state of the embedded editorconfig
 // This includes the severity (info, warning..) as well as the notification-messages for users
 function setState(ecfg) {
@@ -59,8 +61,8 @@ function initializeTextBuffer(buffer) {
 
 			// Get the current Editor for this.buffer
 			getCurrentEditor() {
-				return atom.workspace.getTextEditors().reduce((prev, curr) => {
-					return (curr.getBuffer() === this.buffer && curr) || prev;
+				return atom.workspace.getTextEditors().reduce((previous, current) => {
+					return (current.getBuffer() === this.buffer && current) || previous;
 				}, undefined);
 			},
 
@@ -101,16 +103,16 @@ function initializeTextBuffer(buffer) {
 					}
 
 					// Max_line_length-settings
-					const editorParams = {};
+					const editorParameters = {};
 					if (settings.max_line_length === 'unset') {
-						editorParams.preferredLineLength =
+						editorParameters.preferredLineLength =
 							atom.config.get('editor.preferredLineLength', configOptions);
 					} else {
-						editorParams.preferredLineLength = settings.max_line_length;
+						editorParameters.preferredLineLength = settings.max_line_length;
 					}
 
 					// Update the editor-properties
-					editor.update(editorParams);
+					editor.update(editorParameters);
 
 					// Ensure the wrap-guide is being intercepted
 					const bufferDom = atom.views.getView(editor);
@@ -132,7 +134,7 @@ function initializeTextBuffer(buffer) {
 							wrapGuide.updateGuide();
 						} else {
 							// NB: This won't work with multiple wrap-guides
-							const columnWidth = bufferDom.getDefaultCharacterWidth() * editorParams.preferredLineLength;
+							const columnWidth = bufferDom.getDefaultCharacterWidth() * editorParameters.preferredLineLength;
 							if (columnWidth > 0) {
 								wrapGuide.style.left = Math.round(columnWidth) + 'px';
 								wrapGuide.style.display = 'block';
@@ -217,25 +219,25 @@ function initializeTextBuffer(buffer) {
 					buffer.setText(text);
 				} else {
 					if (settings.end_of_line === '\r\n') {
-						buffer.backwardsScan(/([^\r]|^)\n|\r(?!\n)/g, params => {
-							const {match} = params;
+						buffer.backwardsScan(/([^\r]|^)\n|\r(?!\n)/g, parameters => {
+							const {match} = parameters;
 							if (match && match[0].length > 0) {
-								params.replace((match[1] || '') + '\r\n');
+								parameters.replace((match[1] || '') + '\r\n');
 							}
 						});
 					} else if (settings.end_of_line === '\n') {
-						buffer.backwardsScan(/\r\n|\r([^\n]|$)/g, params => {
-							const {match} = params;
+						buffer.backwardsScan(/\r\n|\r([^\n]|$)/g, parameters => {
+							const {match} = parameters;
 							if (match && match[0].length > 0) {
-								params.replace('\n' + ([match[1]] || ''));
+								parameters.replace('\n' + ([match[1]] || ''));
 							}
 						});
 					}
 
 					if (settings.trim_trailing_whitespace === true) {
-						buffer.backwardsScan(/[ \t]+$/gm, params => {
-							if (params.match[0].length > 0) {
-								params.replace('');
+						buffer.backwardsScan(/[ \t]+$/gm, parameters => {
+							if (parameters.match[0].length > 0) {
+								parameters.replace('');
 							}
 						});
 					}
@@ -442,8 +444,8 @@ module.exports = {
 		if (!atom.packages.hasActivatedInitialPackages()) {
 			const disposables = new CompositeDisposable();
 			disposables.add(
-				atom.packages.onDidActivatePackage(pkg => {
-					if (pkg.name === 'whitespace' || pkg.name === 'wrap-guide') {
+				atom.packages.onDidActivatePackage(currentPackage => {
+					if (currentPackage.name === 'whitespace' || currentPackage.name === 'wrap-guide') {
 						reapplyEditorconfig();
 					}
 				}),

--- a/index.js
+++ b/index.js
@@ -9,6 +9,18 @@ let generateConfig;
 let showState;
 let statusTile;
 let wrapGuideInterceptor;
+let lint;
+
+lint = require('./lib/lint.js');
+
+function provideLinter() {
+	// Auto-magically called by the package linter, see package.json -> "providedServices.linter"
+	if (!lint) {
+		lint = require('./lib/lint.js');
+	}
+
+	return lint.provideLinter();
+}
 
 // Sets the state of the embedded editorconfig
 // This includes the severity (info, warning..) as well as the notification-messages for users
@@ -376,6 +388,8 @@ module.exports = {
 			this.disposables.dispose();
 		}
 
+		require('atom-package-deps').install('editorconfig');
+
 		this.disposables = new CompositeDisposable(
 			atom.commands.add('atom-workspace', {
 				'EditorConfig:fix-file': () => {
@@ -446,6 +460,14 @@ module.exports = {
 			this.disposables.dispose();
 			this.disposables = null;
 		}
+	},
+
+	provideLinter() {
+		if (!lint) {
+			lint = require('./lib/lint.js');
+		}
+
+		return lint.provideLinter();
 	},
 
 	// Apply the statusbar icon-container. The icon will be applied if needed

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ let lint;
 
 lint = require('./lib/lint.js');
 
-function provideLinter() {
+function provideLinter() { // eslint-disable-line no-unused-vars
 	// Auto-magically called by the package linter, see package.json -> "providedServices.linter"
 	if (!lint) {
 		lint = require('./lib/lint.js');
@@ -21,8 +21,6 @@ function provideLinter() {
 
 	return lint.provideLinter();
 }
-
-provideLinter(); // This call is useless but makes XO happy
 
 // Sets the state of the embedded editorconfig
 // This includes the severity (info, warning..) as well as the notification-messages for users

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -251,8 +251,8 @@ export function provideLinter() {
 							// Handle numeric value
 							if (abstractDeclaration[1] === 'unset') {
 								// Ok
-							} else if (abstractDeclaration[0] === 'indent_size' & abstractDeclaration[1] === 'tab') {
-								// Ok: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_size
+							} else if (declarationSupportedValues(abstractDeclaration[0]).slice(1).includes(abstractDeclaration[1])) {
+								// Ok
 							} else if (!abstractDeclaration[1].match(/^[0]$|^[1-9][\d]*$/)) {
 								// Report invalid literal numeric value
 								result.push({

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -7,7 +7,7 @@ function declarationSupportedValues(declarationName) {
 		case 'charset': return ['latin1', 'utf-8', 'utf-8-bom', 'utf-16be', 'utf-16le'];
 		case 'insert_final_newline': return ['true', 'false'];
 		case 'trim_trailing_whitespace': return ['true', 'false'];
-		case 'indent_size': return ['#'];
+		case 'indent_size': return ['#', 'tab'];
 		case 'tab_width': return ['#'];
 		default: return null;
 	}
@@ -251,6 +251,8 @@ export function provideLinter() {
 							// Handle numeric value
 							if (abstractDeclaration[1] === 'unset') {
 								// Ok
+							} else if (abstractDeclaration[0] === 'indent_size' & abstractDeclaration[1] === 'tab') {
+								// Ok: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_size
 							} else if (!abstractDeclaration[1].match(/^[0]$|^[1-9][\d]*$/)) {
 								// Report invalid literal numeric value
 								result.push({

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,10 +1,8 @@
-'use babel';
-
 function declarationSupportedValues(declarationName) {
 	switch (declarationName) {
 		case 'indent_style': return ['tab', 'space'];
 		case 'end_of_line': return ['lf', 'cr', 'crlf'];
-		case 'charset': return ['latin1', 'utf-8', 'utf-8-bom', 'utf-16be', 'utf-16le'];
+		case 'charset': return ['+'];
 		case 'insert_final_newline': return ['true', 'false'];
 		case 'trim_trailing_whitespace': return ['true', 'false'];
 		case 'indent_size': return ['#', 'tab'];
@@ -13,7 +11,7 @@ function declarationSupportedValues(declarationName) {
 	}
 }
 
-export function provideLinter() {
+function provideLinter() {
 	return {
 		name: 'editorconfig',
 		scope: 'file',
@@ -247,6 +245,25 @@ export function provideLinter() {
 								url: 'https://editorconfig-specification.readthedocs.io/en/latest/#supported-pairs',
 								solutions: []
 							});
+						} else if (declarationSupportedValues(abstractDeclaration[0])[0] === '*') {
+							// Handle any value even empty
+							// OK
+						} else if (declarationSupportedValues(abstractDeclaration[0])[0] === '+') {
+							// Handle any value but not empty
+							if (abstractDeclaration[1] === '') {
+								// Report missing value
+								result.push({
+									severity: 'warning',
+									location: {
+										file: editorPath,
+										position: [[lineIndex, concreteDeclaration[0].length], [lineIndex, concreteDeclaration[0].length + 1]]
+									},
+									excerpt: 'Missing value',
+									description: '### The declaration is missing a value',
+									url: 'https://editorconfig-specification.readthedocs.io/en/latest/#supported-pairs',
+									solutions: []
+								});
+							}
 						} else if (declarationSupportedValues(abstractDeclaration[0])[0] === '#') {
 							// Handle numeric value
 							if (abstractDeclaration[1] === 'unset') {
@@ -274,7 +291,7 @@ export function provideLinter() {
 									severity: 'error',
 									location: {
 										file: editorPath,
-										position: [[lineIndex, concreteDeclaration[0].length + 1 + concreteDeclaration[1].length - concreteDeclaration[1].trimStart().length], [lineIndex, concreteLine.length]]
+										position: [[lineIndex, concreteDeclaration[0].length + concreteDeclaration[1].length - concreteDeclaration[1].trimStart().length], [lineIndex, concreteLine.length]]
 									},
 									excerpt: 'Invalid value.',
 									description: 'The value must be \'unset\' or one of: ' + declarationSupportedValues(abstractDeclaration[0]).join(', '),
@@ -323,3 +340,5 @@ export function provideLinter() {
 		}
 	};
 }
+
+module.exports = {provideLinter};

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,0 +1,323 @@
+'use babel';
+
+function declarationSupportedValues(declarationName) {
+	switch (declarationName) {
+		case 'indent_style': return ['tab', 'space'];
+		case 'end_of_line': return ['lf', 'cr', 'crlf'];
+		case 'charset': return ['latin1', 'utf-8', 'utf-8-bom', 'utf-16be', 'utf-16le'];
+		case 'insert_final_newline': return ['true', 'false'];
+		case 'trim_trailing_whitespace': return ['true', 'false'];
+		case 'indent_size': return ['#'];
+		case 'tab_width': return ['#'];
+		default: return null;
+	}
+}
+
+export function provideLinter() {
+	return {
+		name: 'editorconfig',
+		scope: 'file',
+		lintsOnChange: true,
+		grammarScopes: ['source.editorconfig'],
+		lint(textEditor) {
+			const editorPath = textEditor.getPath();
+
+			// Do lint.
+			// severity [info, warning, error]
+			const result = []; // To hold a list of linter messages: https://steelbrain.me/linter/types/linter-message-v2.html
+
+			let sawAHeader = false;
+			let seenDeclaration = [];
+
+			textEditor.getText().split('\n').forEach((concreteLine, lineIndex, lines) => { // Lint a line.
+				const abstractLine = concreteLine.trim();
+
+				if (abstractLine === '') { // Handle empty line.
+					return;
+				}
+
+				if (abstractLine.startsWith(';') | abstractLine.startsWith('#')) { // Handle comment line.
+					return;
+				}
+
+				if (abstractLine.startsWith('\u005B') | abstractLine.endsWith('\u005D')) { // Handle header line.
+					sawAHeader = true;
+					seenDeclaration = [];
+					if (!abstractLine.endsWith('\u005D')) { // Report missing closing bracket.
+						result.push({
+							severity: 'error',
+							location: {
+								file: editorPath,
+								position: [[lineIndex, concreteLine.length - 1], [lineIndex, concreteLine.length]]
+							},
+							excerpt: 'Header line must end with \'\u005D\'',
+							description: '### The header openning block bracket must have a closing bracket.',
+							url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+							solutions: [
+								{
+									title: 'Add a closing header bracket \'\u005D\'',
+									position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]],
+									priority: 0,
+									apply: ((lineIndex, lines) => {
+										return () => {
+											lines[lineIndex] = lines[lineIndex].trimRight() + '\u005D';
+											textEditor.setText(lines.join('\n'), {});
+										};
+									})(lineIndex, lines)
+								}
+							]
+						});
+					}
+
+					if (!abstractLine.startsWith('\u005B')) { // Report missing opening bracket.
+						result.push({
+							severity: 'error',
+							location: {
+								file: editorPath,
+								position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]]
+							},
+							excerpt: 'Header line must start with \'\u005B\'',
+							description: '### The header openning block bracket must have an opening bracket.',
+							url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+							solutions: [
+								{
+									title: 'Add an opening header bracket \'\u005B\'',
+									position: [[lineIndex, 0], [lineIndex, 1]],
+									priority: 0,
+									apply: ((lineIndex, lines) => {
+										return () => {
+											lines[lineIndex] = '\u005B' + (lines[lineIndex].trimLeft());
+											textEditor.setText(lines.join('\n'), {});
+										};
+									})(lineIndex, lines)
+								}
+							]
+						});
+					}
+
+					return;
+				}
+				// Handle declarations line.
+
+				const concreteDeclaration = concreteLine.split('=');
+				const abstractDeclaration = concreteDeclaration.map(x => x.trim().toLowerCase());
+				if (seenDeclaration.includes(abstractDeclaration[0])) {
+					result.push({
+						severity: 'warning',
+						location: {
+							file: editorPath,
+							position: [[lineIndex, 0], [lineIndex, concreteDeclaration[0].length]]
+						},
+						excerpt: 'Duplicate entry',
+						description: '### The declaration name appears more than once within the current header block',
+						url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+						solutions: [
+							{
+								title: 'Remove this duplicate entry',
+								position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]],
+								priority: 0,
+								apply: ((lineIndex, lines) => {
+									return () => {
+										lines.splice(lineIndex, 1);
+										textEditor.setText(lines.join('\n'), {});
+									};
+								})(lineIndex, lines)
+							}
+						]
+					});
+				} else {
+					seenDeclaration.push(abstractDeclaration[0]);
+				}
+
+				if (concreteDeclaration.length === 1) { // Report missing equal sign.
+					result.push({
+						severity: 'error',
+						location: {
+							file: editorPath,
+							position: [[lineIndex, concreteLine.length - 1], [lineIndex, concreteLine.length]]
+						},
+						excerpt: 'Declaration line must have an equal symbol\'=\'',
+						description: '### The declaration must have an equal symbol to separate the property name from its value.',
+						url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+						solutions: [
+							{
+								title: 'Add an equal symbol \'=\'',
+								position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]],
+								priority: 0,
+								apply: ((lineIndex, lines) => {
+									return () => {
+										lines[lineIndex] = lines[lineIndex].trimRight() + '=';
+										textEditor.setText(lines.join('\n'), {});
+									};
+								})(lineIndex, lines)
+							}
+						]
+					});
+				} else if (concreteDeclaration.length === 2) {
+					// The number of equal sign is as expected.
+					if (abstractDeclaration[0] === 'root') {
+						// Handle root separately since it has some special rules.
+						if (sawAHeader) {
+							result.push({
+								severity: 'error',
+								location: {
+									file: editorPath,
+									position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]]
+								},
+								excerpt: 'Declaration line \'root\' must be before all header line',
+								description: '### The declaration \'root\' must be in the preamble of the file.',
+								url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+								solutions: [
+									{
+										title: 'Remove this \'root\' declaration',
+										position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]],
+										priority: 0,
+										apply: ((lineIndex, lines) => {
+											return () => {
+												lines.splice(lineIndex, 1);
+												textEditor.setText(lines.join('\n'), {});
+											};
+										})(lineIndex, lines)
+									},
+									{
+										title: 'Move \'root\' declaration to top of file',
+										position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]],
+										priority: 1,
+										apply: ((lineIndex, lines) => {
+											return () => {
+												lines.unshift(lines[lineIndex]);
+												lines.splice(lineIndex + 1, 1);
+												textEditor.setText(lines.join('\n'), {});
+											};
+										})(lineIndex, lines)
+									}
+								]
+							});
+						}
+
+						if (!['true', 'false'].includes(abstractDeclaration[1])) {
+							result.push({
+								severity: 'error',
+								location: {
+									file: editorPath,
+									position: [[lineIndex, concreteDeclaration[0].length + 1 + concreteDeclaration[1].length - concreteDeclaration[1].trimStart().length], [lineIndex, concreteLine.length]]
+								},
+								excerpt: 'Invalid value.',
+								description: 'The only valid value for \'root\' declaration are true and false.',
+								url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+								solutions: []
+							});
+						}
+					} else {
+						if (!sawAHeader) {
+							result.push({
+								severity: 'error',
+								location: {
+									file: editorPath,
+									position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]]
+								},
+								excerpt: 'Only \'root\' Declaration line can be present within the file preamble',
+								description: '### The declaration must not be in the preamble of the file.',
+								url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+								solutions: [
+									{
+										title: 'Remove this \'' + abstractDeclaration[0] + '\' declaration',
+										position: [[lineIndex, 0], [lineIndex, concreteLine.length - 1]],
+										priority: 0,
+										apply: ((lineIndex, lines) => {
+											return () => {
+												lines.splice(lineIndex, 1);
+												textEditor.setText(lines.join('\n'), {});
+											};
+										})(lineIndex, lines)
+									}
+								]
+							});
+						}
+
+						if (declarationSupportedValues(abstractDeclaration[0]) === null) { // Handle Unrecognized declaration name.
+							result.push({
+								severity: 'warning',
+								location: {
+									file: editorPath,
+									position: [[lineIndex, 0], [lineIndex, concreteDeclaration[0].length]]
+								},
+								excerpt: 'Unrecognized declaration name',
+								description: '### The declaration is using a non-standard supported name',
+								url: 'https://editorconfig-specification.readthedocs.io/en/latest/#supported-pairs',
+								solutions: []
+							});
+						} else if (declarationSupportedValues(abstractDeclaration[0])[0] === '#') {
+							// Handle numeric value
+							if (abstractDeclaration[1] === 'unset') {
+								// Ok
+							} else if (!abstractDeclaration[1].match(/^[0]$|^[1-9][\d]*$/)) {
+								// Report invalid literal numeric value
+								result.push({
+									severity: 'error',
+									location: {
+										file: editorPath,
+										position: [[lineIndex, concreteDeclaration[0].length + 1 + concreteDeclaration[1].length - concreteDeclaration[1].trimStart().length], [lineIndex, concreteLine.length]]
+									},
+									excerpt: 'Invalid number.',
+									description: 'The value must be \'unset\' or a positive base 10 number.',
+									url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+									solutions: []
+								});
+							}
+						} else if (abstractDeclaration[1] !== 'unset') {
+							if (!declarationSupportedValues(abstractDeclaration[0]).includes(abstractDeclaration[1])) {
+								// Report value not part of the valid enumeration
+								result.push({
+									severity: 'error',
+									location: {
+										file: editorPath,
+										position: [[lineIndex, concreteDeclaration[0].length + 1 + concreteDeclaration[1].length - concreteDeclaration[1].trimStart().length], [lineIndex, concreteLine.length]]
+									},
+									excerpt: 'Invalid value.',
+									description: 'The value must be \'unset\' or one of: ' + declarationSupportedValues(abstractDeclaration[0]).join(', '),
+									url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+									solutions: []
+								});
+							}
+						}
+					}
+				} else { // Report too many equal sign.
+					let extraEqualIndex = 1;
+
+					concreteDeclaration.forEach((declarationPart, index, _) => {
+						extraEqualIndex += declarationPart.length;
+						if (index > 1) { // Report extra equal sign.
+							result.push({
+								severity: 'error',
+								location: {
+									file: editorPath,
+									position: [[lineIndex, extraEqualIndex], [lineIndex, extraEqualIndex + 1]]
+								},
+								excerpt: 'Declaration line must have only one equal symbol\'=\'',
+								description: '### The declaration must have only one equal symbol to separate the property name from its value.',
+								url: 'https://editorconfig-specification.readthedocs.io/en/latest/#file-processing',
+								solutions: [
+									{
+										title: 'Remove the extra equal symbol \'=\'',
+										position: [[lineIndex, extraEqualIndex], [lineIndex, extraEqualIndex + 1]],
+										priority: 0,
+										apply: ((lineIndex, lines, extraEqualIndex) => {
+											return () => {
+												lines[lineIndex] = lines[lineIndex].slice(0, extraEqualIndex) + lines[lineIndex].slice(extraEqualIndex + 1, lines[lineIndex].length);
+												textEditor.setText(lines.join('\n'), {});
+											};
+										})(lineIndex, lines, extraEqualIndex)
+									}
+								]
+							});
+						}
+					});
+				}
+			});
+			return new Promise(resolve => {
+				resolve(result);
+			});
+		}
+	};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,17 +229,6 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
-		"atom-linter": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/atom-linter/-/atom-linter-10.0.0.tgz",
-			"integrity": "sha1-0nu3Tl+PCKdKQL6ynuGlDZdUPIk=",
-			"requires": {
-				"named-js-regexp": "^1.3.1",
-				"sb-exec": "^4.0.0",
-				"sb-promisify": "^2.0.1",
-				"tmp": "~0.0.28"
-			}
-		},
 		"atom-mocha": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/atom-mocha/-/atom-mocha-2.2.0.tgz",
@@ -251,22 +240,6 @@
 				"mocha": "^6.1.4",
 				"mocha-when": "^1.0.0",
 				"print": "^1.1.0"
-			}
-		},
-		"atom-package-deps": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-5.1.0.tgz",
-			"integrity": "sha512-RGktH8NSFBJ5rdwuta3M7DbFdDr1EgrXo7uW7DQR/+lWJZcrfH2yxobnSdb/g1JM1tTvLyRYmZYOeRJGqQ9UGw==",
-			"requires": {
-				"sb-fs": "^4.0.0",
-				"semver": "^6.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"balanced-match": {
@@ -665,14 +638,6 @@
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}
-			}
-		},
-		"consistent-env": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
-			"integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
-			"requires": {
-				"lodash.uniq": "^4.5.0"
 			}
 		},
 		"contains-path": {
@@ -2411,11 +2376,6 @@
 				"has-symbols": "^1.0.0"
 			}
 		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2589,11 +2549,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
 			"integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
 			"dev": true
-		},
-		"lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -3005,11 +2960,6 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
-		"named-js-regexp": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.5.tgz",
-			"integrity": "sha512-XO0DPujDP9IWpkt690iWLreKztb/VB811DGl5N3z7BfhkMJuiVZXOi6YN/fEB9qkvtMVTgSZDW8pzdVt8vj/FA=="
-		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -3241,7 +3191,8 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"p-defer": {
 			"version": "1.0.0",
@@ -3930,43 +3881,6 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"sb-exec": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-4.0.0.tgz",
-			"integrity": "sha1-RnR/DfFiYmwW6/D+pCJFrRqoWco=",
-			"requires": {
-				"consistent-env": "^1.2.0",
-				"lodash.uniq": "^4.5.0",
-				"sb-npm-path": "^2.0.0"
-			}
-		},
-		"sb-fs": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-4.0.0.tgz",
-			"integrity": "sha512-UjjIHC4uahPWvKYqgknvFCCJ11S0oDahz+nsmyTCAmARKto31aoE+Lu7GGGK0nogengJEKGzFdh46ho5+IL88Q==",
-			"requires": {
-				"strip-bom-buf": "^1.0.0"
-			}
-		},
-		"sb-memoize": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
-			"integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
-		},
-		"sb-npm-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
-			"integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
-			"requires": {
-				"sb-memoize": "^1.0.2",
-				"sb-promisify": "^2.0.1"
-			}
-		},
-		"sb-promisify": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
-			"integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
-		},
 		"semver": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -4308,14 +4222,6 @@
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 			"dev": true
 		},
-		"strip-bom-buf": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-			"requires": {
-				"is-utf8": "^0.2.1"
-			}
-		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -4489,6 +4395,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "editorconfig",
-	"version": "2.4.0",
+	"version": "2.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -229,6 +229,17 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
+		"atom-linter": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/atom-linter/-/atom-linter-10.0.0.tgz",
+			"integrity": "sha1-0nu3Tl+PCKdKQL6ynuGlDZdUPIk=",
+			"requires": {
+				"named-js-regexp": "^1.3.1",
+				"sb-exec": "^4.0.0",
+				"sb-promisify": "^2.0.1",
+				"tmp": "~0.0.28"
+			}
+		},
 		"atom-mocha": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/atom-mocha/-/atom-mocha-2.2.0.tgz",
@@ -240,6 +251,22 @@
 				"mocha": "^6.1.4",
 				"mocha-when": "^1.0.0",
 				"print": "^1.1.0"
+			}
+		},
+		"atom-package-deps": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-5.1.0.tgz",
+			"integrity": "sha512-RGktH8NSFBJ5rdwuta3M7DbFdDr1EgrXo7uW7DQR/+lWJZcrfH2yxobnSdb/g1JM1tTvLyRYmZYOeRJGqQ9UGw==",
+			"requires": {
+				"sb-fs": "^4.0.0",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"balanced-match": {
@@ -638,6 +665,14 @@
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}
+			}
+		},
+		"consistent-env": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
+			"integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
+			"requires": {
+				"lodash.uniq": "^4.5.0"
 			}
 		},
 		"contains-path": {
@@ -1315,10 +1350,21 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-			"dev": true
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+					"dev": true
+				}
+			}
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -2365,6 +2411,11 @@
 				"has-symbols": "^1.0.0"
 			}
 		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2538,6 +2589,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
 			"integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
 			"dev": true
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -2949,6 +3005,11 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
+		"named-js-regexp": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.5.tgz",
+			"integrity": "sha512-XO0DPujDP9IWpkt690iWLreKztb/VB811DGl5N3z7BfhkMJuiVZXOi6YN/fEB9qkvtMVTgSZDW8pzdVt8vj/FA=="
+		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -3180,8 +3241,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-defer": {
 			"version": "1.0.0",
@@ -3870,6 +3930,43 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"sb-exec": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-4.0.0.tgz",
+			"integrity": "sha1-RnR/DfFiYmwW6/D+pCJFrRqoWco=",
+			"requires": {
+				"consistent-env": "^1.2.0",
+				"lodash.uniq": "^4.5.0",
+				"sb-npm-path": "^2.0.0"
+			}
+		},
+		"sb-fs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-4.0.0.tgz",
+			"integrity": "sha512-UjjIHC4uahPWvKYqgknvFCCJ11S0oDahz+nsmyTCAmARKto31aoE+Lu7GGGK0nogengJEKGzFdh46ho5+IL88Q==",
+			"requires": {
+				"strip-bom-buf": "^1.0.0"
+			}
+		},
+		"sb-memoize": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
+			"integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
+		},
+		"sb-npm-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
+			"integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
+			"requires": {
+				"sb-memoize": "^1.0.2",
+				"sb-promisify": "^2.0.1"
+			}
+		},
+		"sb-promisify": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
+			"integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
+		},
 		"semver": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -4211,6 +4308,14 @@
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 			"dev": true
 		},
+		"strip-bom-buf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"requires": {
+				"is-utf8": "^0.2.1"
+			}
+		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -4384,7 +4489,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}

--- a/package.json
+++ b/package.json
@@ -27,17 +27,12 @@
 	"atomTestRunner": "atom-mocha",
 	"dependencies": {
 		"editorconfig": "^0.15.3",
-		"mapped-disposable": "^1.0.3",
-		"atom-linter": "^10.0.0",
-		"atom-package-deps": "^5.0.0"
+		"mapped-disposable": "^1.0.3"
 	},
 	"devDependencies": {
 		"atom-mocha": "^2.2.0",
 		"xo": "^0.24.0"
 	},
-	"package-deps": [
-		"linter"
-	],
 	"xo": {
 		"globals": [
 			"AtomMocha",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 			"atom/**"
 		],
 		"rules": {
+			"complexity": ["error", 25],
 			"import/prefer-default-export": "off",
 			"max-nested-callbacks": "off",
 			"camelcase": [

--- a/package.json
+++ b/package.json
@@ -27,12 +27,17 @@
 	"atomTestRunner": "atom-mocha",
 	"dependencies": {
 		"editorconfig": "^0.15.3",
-		"mapped-disposable": "^1.0.3"
+		"mapped-disposable": "^1.0.3",
+		"atom-linter": "^10.0.0",
+		"atom-package-deps": "^5.0.0"
 	},
 	"devDependencies": {
 		"atom-mocha": "^2.2.0",
 		"xo": "^0.24.0"
 	},
+	"package-deps": [
+		"linter"
+	],
 	"xo": {
 		"globals": [
 			"AtomMocha",
@@ -85,6 +90,13 @@
 		"status-bar": {
 			"versions": {
 				"^1.0.0": "consumeStatusBar"
+			}
+		}
+	},
+	"providedServices": {
+		"linter": {
+			"versions": {
+				"2.0.0": "provideLinter"
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ See the EditorConfig [documentation](http://editorconfig.org) for a detailed des
 - Applies the settings from your `.editorconfig` file
 - Ability to fix `indent_style` and `end_of_line` issues
 - Syntax highlights `.editorconfig` files (now with specification-like case insensitivity)
+- Lint `.editorconfig` file
 - Ability to generate an `.editorconfig` file based on the current settings
 - Displays a nifty :mouse: in the statusBar whose color shows you if EditorConfig faces any problems
 - Clicking on the :mouse: invokes the `Show State` command for you

--- a/spec/fixtures/lint/happy_path/.editorconfig
+++ b/spec/fixtures/lint/happy_path/.editorconfig
@@ -1,0 +1,74 @@
+root=true
+# Happy path
+
+; No lint msg should be created when analyzing this file.
+
+# Check handling of comment with #
+; Check handling of comment with ;
+
+# Check unset for all supported declaration name
+[*.unset]
+indent_style=unset
+[*.unset]
+end_of_line=unset
+[*.unset]
+charset=unset
+[*.unset]
+insert_final_newline=unset
+[*.unset]
+trim_trailing_whitespace=unset
+[*.unset]
+indent_size=unset
+[*.unset]
+tab_width=unset
+[*.f]
+
+# Check every supported declaration name * all their possible value.
+
+[*.a]
+indent_style=tab
+[*.b]
+indent_style=space
+[*.c]
+end_of_line=lf
+[*.d]
+end_of_line=cr
+[*.e]
+end_of_line=crlf
+[*.f]
+charset=utf-8
+[*.g]
+insert_final_newline=true
+[*.h]
+insert_final_newline=false
+[*.i]
+trim_trailing_whitespace=true
+[*.j]
+trim_trailing_whitespace=false
+[*.k]
+indent_size=0
+[*.l]
+indent_size=1
+[*.m]
+indent_size=11
+[*.n]
+tab_width=0
+[*.o]
+tab_width=1
+[*.p]
+tab_width=11
+
+
+
+
+# Test spacing
+
+
+
+
+    [  *  .  spacing  ]
+
+
+
+
+	       	indent_style		  		 =       	 space

--- a/spec/lint-spec.js
+++ b/spec/lint-spec.js
@@ -96,19 +96,26 @@ describe('Lint related tests', () => {
 		});
 		it('may report lint messages with result.push #8', async () => {
 			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*.abc]\ncharset=\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Missing value');
+		});
+		it('may report lint messages with result.push #9', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
 			textEditor.setText('[*]\nindent_size=a\n');
 			const result = await lintMethod(textEditor);
 			expect(result.length).to.equal(1);
 			expect(result[0].excerpt).to.equal('Invalid number.');
 		});
-		it('may report lint messages with result.push #9', async () => {
+		it('may report lint messages with result.push #10', async () => {
 			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
 			textEditor.setText('root=maybe\n');
 			const result = await lintMethod(textEditor);
 			expect(result.length).to.equal(1);
 			expect(result[0].excerpt).to.equal('Invalid value.');
 		});
-		it('may report lint messages with result.push #10', async () => {
+		it('may report lint messages with result.push #11', async () => {
 			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
 			textEditor.setText('root==true\n');
 			const result = await lintMethod(textEditor);
@@ -118,6 +125,12 @@ describe('Lint related tests', () => {
 		it('correctly handle a value of tab for indent_size', async () => {
 			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
 			textEditor.setText('[*.abc]\nindent_size=tab\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(0);
+		});
+		it('correctly handle any value for charset', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*.abc]\ncharset=def\n'); // The value of def is not a known charset
 			const result = await lintMethod(textEditor);
 			expect(result.length).to.equal(0);
 		});

--- a/spec/lint-spec.js
+++ b/spec/lint-spec.js
@@ -9,6 +9,7 @@ const path = require('path');
 const projectRoot = path.join(__dirname, 'fixtures');
 
 const {provideLinter} = require('../lib/lint.js');
+
 const lintMethod = provideLinter().lint;
 
 describe('Lint related tests', () => {

--- a/spec/lint-spec.js
+++ b/spec/lint-spec.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/*
+	This file contains verifying specs for: lint.js (Linting feature).
+*/
+
+const path = require('path');
+
+const projectRoot = path.join(__dirname, 'fixtures');
+
+const {provideLinter} = require('../lib/lint.js');
+const lintMethod = provideLinter().lint;
+
+describe('Lint related tests', () => {
+	when('linting a .editorconfig file', () => {
+		let textEditor = null;
+
+		beforeEach('Activating package', async () => {
+			attachToDOM(atom.views.getView(atom.workspace));
+			await atom.packages.activatePackage(path.join(__dirname, '..'));
+		});
+
+		it('It can report some lint messages', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('_');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.not.equal(0);
+		});
+		it('does not report lint messages on empty file', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(0);
+		});
+		it('does not report lint messages if everything is fine', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', 'happy_path', '.editorconfig'));
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(0);
+		});
+		it('may report lint messages with result.push #0', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Header line must end with \'\u005D\'');
+		});
+		it('may report lint messages with result.push #1', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText(']');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Header line must start with \'\u005B\'');
+		});
+		it('may report lint messages with result.push #2', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('root=true\nroot=true\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Duplicate entry');
+		});
+		it('may report lint messages with result.push #3', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('root\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Declaration line must have an equal symbol\'=\'');
+		});
+		it('may report lint messages with result.push #4', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*]\nroot=true\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Declaration line \'root\' must be before all header line');
+		});
+		it('may report lint messages with result.push #5', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('root=Nop\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Invalid value.');
+		});
+		it('may report lint messages with result.push #6', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('indent_style=unset\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Only \'root\' Declaration line can be present within the file preamble');
+		});
+		it('may report lint messages with result.push #7', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*]\nx=y\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Unrecognized declaration name');
+		});
+		it('may report lint messages with result.push #8', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*]\nindent_size=a\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Invalid number.');
+		});
+		it('may report lint messages with result.push #9', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('root=maybe\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Invalid value.');
+		});
+		it('may report lint messages with result.push #10', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('root==true\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1);
+			expect(result[0].excerpt).to.equal('Declaration line must have only one equal symbol\'=\'');
+		});
+
+		it('may fix some issue', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*.abc\n');
+			let result = await lintMethod(textEditor);
+			expect(result.length).to.equal(1); // A lint msg is present.
+			expect(result[0].solutions.length).to.not.equal(0); // Some solutions are available
+			result[0].solutions[0].apply(); // Apply a solution
+			result = await lintMethod(textEditor);
+			expect(result.length).to.equal(0); // No more lint msg are present
+		});
+	});
+});

--- a/spec/lint-spec.js
+++ b/spec/lint-spec.js
@@ -115,7 +115,12 @@ describe('Lint related tests', () => {
 			expect(result.length).to.equal(1);
 			expect(result[0].excerpt).to.equal('Declaration line must have only one equal symbol\'=\'');
 		});
-
+		it('correctly handle a value of tab for indent_size', async () => {
+			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
+			textEditor.setText('[*.abc]\nindent_size=tab\n');
+			const result = await lintMethod(textEditor);
+			expect(result.length).to.equal(0);
+		});
 		it('may fix some issue', async () => {
 			textEditor = await atom.workspace.open(path.join(projectRoot, 'lint', '.editorconfig'));
 			textEditor.setText('[*.abc\n');


### PR DESCRIPTION
To make the maintainer's life easier, I...

- [X] created at least 1 spec to cover my changes,
- [X] `npm test`ed my code and it's green like an :green_apple:,
- [X] adjusted the `readme.md`, if it was necessary and
- [X] would like to receive get a :beer: or :coffee: after that hard work!

This pull request adds linting feature when editing .editorconfig file.

It solves issue #141


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#141: Notify user about malformed editorconfig-files](https://issuehunt.io/repos/17411980/issues/141)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->